### PR TITLE
authorise provideritems/index endpoint

### DIFF
--- a/app/controllers/api/provider/items_controller.rb
+++ b/app/controllers/api/provider/items_controller.rb
@@ -31,6 +31,7 @@ module Api
   ]
 }}
       def index
+        authorize ProviderItem
         @provider_items = provider_scope
       end
 

--- a/spec/requests/api/providers/items/index_spec.rb
+++ b/spec/requests/api/providers/items/index_spec.rb
@@ -2,6 +2,17 @@ require "rails_helper"
 
 RSpec.describe Api::Provider::ItemsController,
                type: :request do
+  describe "as non-provider" do
+    let(:user) { create :user }
+    before {
+      login_as user
+      get_with_headers "/api/provider/items"
+    }
+    it "says I'm not authorised" do
+      expect(response.status).to eq(401)
+    end
+  end
+
   describe "as provider" do
     let(:provider) { create :user, :provider }
     before { login_as provider }


### PR DESCRIPTION
so that we don’t fatal if a non-provider GETs this endpoint

related:
- http://pangi.shiriculapo.com/apps/577670c995ca4e3219000021/problems/57c465a295ca4e044a000007
- http://nodriza.noggalito.com/issues/641
